### PR TITLE
feat: Create reusable input field component

### DIFF
--- a/src/components/input-field.tsx
+++ b/src/components/input-field.tsx
@@ -1,0 +1,59 @@
+//input-field.tsk
+
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import  TextField  from '@mui/material/TextField';
+
+
+interface Field {
+    id: string;
+    label: string;
+    variant: 'outlined' | 'filled' | 'standard';
+    defaultValue?: string;
+    
+
+}
+
+interface Props {
+    fields: Field[];
+}
+
+
+export default function BasicTextField({fields}: Props){
+    return (
+        <Box
+        component="form"
+        sx={{
+            '& > :not(style)': { m: 1, width: '25ch'},
+        }}
+        noValidate
+        autoComplete="off"
+        >
+            {fields.map((field) =>(
+            <TextField
+            key={field.id}
+            id={field.id}
+            label= {field.label}
+            variant={field.variant}
+            defaultValue={field.defaultValue}
+
+            // the above are props that have been passed to the textfield component
+            />
+            ))}
+        </Box>
+    );
+}
+
+// How to use component in the main File
+
+// import BasicTextFields from './BasicTextFields';
+
+// export default function MyForm() {
+//   const fields = [
+//     { id: 'outlined-basic', label: 'Outlined', variant: 'outlined', defaultValue: '' },
+//     { id: 'filled-basic', label: 'Filled', variant: 'filled', defaultValue: '' },
+//     { id: 'standard-basic', label: 'Standard', variant: 'standard', defaultValue: '' },
+//   ];
+
+//   return <BasicTextFields fields={fields} />;
+// }


### PR DESCRIPTION
Added a reusable input field component (BasicTextField)
 that accepts an array of field configurations as props.
 Each field configuration includes an id, label, variant,
 and optional defaultValue. This component renders a form containing multiple TextField components based on the provided field configurations.
closes #33